### PR TITLE
Fixed pdf links in papers.

### DIFF
--- a/src/lib/components/Paper.svelte
+++ b/src/lib/components/Paper.svelte
@@ -20,10 +20,6 @@
         apa = !apa;
     }
 
-    function getLocalURL() {
-        return `/papers/${paper.local}`;
-    }
-
     // Highlight the citation if expanded.
     afterUpdate(() => {
         if (apa) {
@@ -42,10 +38,12 @@
         }
     });
 
+    $: paperLocalURL = `/papers/${paper.local}`;
+
     $: url =
         // If there's a local, show it first, since digital libraries have my deadname.
         paper.local
-            ? getLocalURL()
+            ? paperLocalURL
             : // If we don't have one, but there's an ACM authorizer URL, return it, because visitors will be able to bypass the paywall.
             paper.authorizer
             ? paper.authorizer
@@ -107,7 +105,7 @@
                         >{apa ? '▾ cite' : '▸ cite'}</span
                     >
                     {#if paper.local}<span>
-                            &sdot; <Link to={getLocalURL()}>pdf</Link></span
+                            &sdot; <Link to={paperLocalURL}>pdf</Link></span
                         >{/if}
                     {#if paper.doi}<span>
                             &sdot; <External to={paper.doi}>doi</External></span


### PR DESCRIPTION
Hi! I was reading more of your research on your site after being inspired by your talk "Searching for Justice in Programming Language Design", when I noticed some "pdf" links on your Publications page were scrambled. When I saw that your site is made with Svelte and its source is on GitHub, I decided to try fixing the problem myself:

It seems both [title](https://github.com/amyjko/faculty/blob/af7b5e5fcd5cebdce49288f8f4fabded120a1971/src/lib/components/Paper.svelte#L89) and ["pdf"](https://github.com/amyjko/faculty/blob/af7b5e5fcd5cebdce49288f8f4fabded120a1971/src/lib/components/Paper.svelte#L110) URLs in [`Paper.svelte`](https://github.com/amyjko/faculty/blob/df5a360c6d65d517ba6d5d6313898120d6d4a98e/src/lib/components/Paper.svelte) were using [a `getLocalURL()` function](https://github.com/amyjko/faculty/blob/af7b5e5fcd5cebdce49288f8f4fabded120a1971/src/lib/components/Paper.svelte#L23-L25) that was not reactive to filter changes in the Facets component. The title URLs were correct because they used [the `url` reactive statement](https://github.com/amyjko/faculty/blob/af7b5e5fcd5cebdce49288f8f4fabded120a1971/src/lib/components/Paper.svelte#L45), but the "pdf" links below each paper used the function directly, and ended up with the same URLs as the original filter produced. So they were correct at first, but did not change when you selected a topic filter button above the list, so were no longer matching the shown paper.

I think there are a couple other ways this could be fixed including passing a `paper` object to `getLocalURL()`, but using a new reactive statement for the local paper URL seemed to work fine and fixed the issue. No worries if you prefer a different way!

I'm very grateful for your work! 😄

Thanks,
—Karlin