### PR TITLE
Some minor commitment page formatting edits

### DIFF
--- a/src/routes/(app)/commitments/DateRange.svelte
+++ b/src/routes/(app)/commitments/DateRange.svelte
@@ -14,7 +14,7 @@
             ' ' +
             date.getDate() +
             (showYear
-                ? ", '" + date.getFullYear().toString().substring(-2)
+                ? ", " + date.getFullYear().toString().substring(-2)
                 : '')
         );
     }

--- a/src/routes/(app)/commitments/DateRange.svelte
+++ b/src/routes/(app)/commitments/DateRange.svelte
@@ -25,13 +25,13 @@
     <span
         ><em>{Math.round((10 * range) / yearInMilliseconds) / 10} years</em><br
         />starting <em>{toDateString(start)}</em></span
-    >;
+    >
     <!-- If it's longer than a week, do weeks -->
 {:else if range >= weekInMilliseconds}
     <span
         ><em>{Math.round(range / weekInMilliseconds)} weeks</em><br />starting
         <em>{toDateString(start)}</em></span
-    >;
+    >
 {:else}
     <!-- If it's less than a week, just do the dates -->
     <span


### PR DESCRIPTION
There is currently a single quotation mark/apostrophe before the year in commitments (e.g., `Oct 1, '2021`). This removes that (e.g., `Oct 1, 2021`).